### PR TITLE
Add Spring MVC and OpenAPI configuration

### DIFF
--- a/mvc/build.gradle
+++ b/mvc/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'war'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = JavaVersion.VERSION_17
+
+def springVersion = '5.1.18.RELEASE'
+def springDocVersion = '1.6.15'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.springframework:spring-webmvc:${springVersion}"
+    implementation "org.springdoc:springdoc-openapi-webmvc-core:${springDocVersion}"
+    implementation "org.springdoc:springdoc-openapi-ui:${springDocVersion}"
+
+    providedCompile 'javax.servlet:javax.servlet-api:4.0.1'
+
+    testImplementation 'junit:junit:4.13.2'
+}
+

--- a/mvc/src/main/java/com/example/mvc/config/OpenApiConfig.java
+++ b/mvc/src/main/java/com/example/mvc/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.example.mvc.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.SpringDocConfiguration;
+import org.springdoc.webmvc.core.SpringDocWebMvcConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({SpringDocConfiguration.class, SpringDocWebMvcConfiguration.class})
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(new Info().title("Example API").version("1.0.0"));
+    }
+}
+

--- a/mvc/src/main/java/com/example/mvc/config/WebAppInitializer.java
+++ b/mvc/src/main/java/com/example/mvc/config/WebAppInitializer.java
@@ -1,0 +1,24 @@
+package com.example.mvc.config;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+import org.springframework.web.WebApplicationInitializer;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+public class WebAppInitializer implements WebApplicationInitializer {
+
+    @Override
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+        context.register(WebMvcConfig.class, OpenApiConfig.class);
+
+        DispatcherServlet dispatcher = new DispatcherServlet(context);
+        ServletRegistration.Dynamic registration = servletContext.addServlet("dispatcher", dispatcher);
+        registration.setLoadOnStartup(1);
+        registration.addMapping("/");
+    }
+}
+

--- a/mvc/src/main/java/com/example/mvc/config/WebMvcConfig.java
+++ b/mvc/src/main/java/com/example/mvc/config/WebMvcConfig.java
@@ -1,0 +1,12 @@
+package com.example.mvc.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = "com.example.mvc")
+public class WebMvcConfig {
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'webfluxElastic'
+include 'mvc'


### PR DESCRIPTION
## Summary
- add standalone `mvc` module configured for Spring 5.1.18 MVC
- wire in springdoc OpenAPI 3 for Swagger UI
- register DispatcherServlet via `WebAppInitializer`

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '2.7.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895fd288b48832daefbe5c6ad4f3bf8